### PR TITLE
Updates

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -13,6 +13,7 @@ Plug 'junegunn/fzf.vim' " Grepping
 Plug 'scrooloose/nerdtree' " Filetree explorer
 Plug 'tpope/vim-fugitive' " Git blame
 Plug 'tpope/vim-surround' " Easy quotes/parenthesizing
+Plug 'tpope/vim-repeat' " Allows . to repeat other custom commands
 Plug 'tomtom/tcomment_vim' " Comment toggling
 Plug 'AndrewRadev/splitjoin.vim' " Quick toggling of single- and multi- line blocks
 Plug 'Valloric/YouCompleteMe' " Autocomplete
@@ -127,6 +128,12 @@ map <silent> <D-9> :tabn 9<cr>
 
 command! Q :q
 command! W :w
+command! WA :wa
+command! Wa :wa
+command! QA :qa
+command! Qa :qa
+
+au BufReadPost,BufNewFile *.rb iabbrev pry require 'pry'; binding.pry
 " ============================================================================
 " Make nerdtree look nice
 let NERDTreeMinimalUI = 1


### PR DESCRIPTION
1. Add vim-repeat plugin to allow custom tpope commands to repeat with "."
2. Ignore case for :wa and :qa since i always type :Qa and :Wa
3. pry shortcut